### PR TITLE
Add sphinx-tabs to extension set

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,10 +39,11 @@ release = "0.1"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_copybutton",
     "sphinx.ext.githubpages",
     "sphinx.ext.todo",
+    "sphinx_copybutton",
     "sphinx_rtd_theme",
+    "sphinx_tabs.tabs",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
-sphinx_rtd_theme
 sphinx-copybutton
+sphinx-tabs
+sphinx_rtd_theme


### PR DESCRIPTION
This is related to https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/248. There, we use sphinx-tabs, so we have to add it to the assembled documentation, as well.