### PR TITLE
Allow wrapping inside codeblocks

### DIFF
--- a/_static/css/ur_theme.css
+++ b/_static/css/ur_theme.css
@@ -313,7 +313,7 @@ body {
 }
 
 .rst-content div[class^=highlight] pre {
-    white-space: pre;
+    white-space: pre-wrap !important;
     margin: 0;
     padding: 12px;
     display: block;


### PR DESCRIPTION
This should make longer lines easier to read on non-ultra-wide screens.