### PR TITLE
Update description branch for Jazzy

### DIFF
--- a/doc/build_status.rst
+++ b/doc/build_status.rst
@@ -116,7 +116,7 @@ ur_description
    <table width="100%" class="docutils align-default">
      <tr>
        <th>Humble (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/humble">humble</a>)</th>
-       <th>Jazzy (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/rolling">rolling</a>)</th>
+       <th>Jazzy (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/jazzy">rolling</a>)</th>
        <th>Kilted (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/rolling">rolling</a>)</th>
        <th>Rolling (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/rolling">rolling</a>)</th>
      </tr>


### PR DESCRIPTION
With jazzy being branched out, we can update the branch on the build overview.