### PR TITLE
Add ur_rtde_ros2_publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc/ur_description/
 doc/ur_robot_driver/
 doc/ur_simulation_gz/
 doc/ur_tutorials/
+doc/ur_rtde_ros2_publisher/

--- a/humble.repos
+++ b/humble.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Tutorials.git
     version: humble
+  ur_rtde_ros2_publisher:
+    type: git
+    url: https://github.com/UniversalRobots/RTDE_ROS2_Publisher.git
+    version: jazzy

--- a/index.rst
+++ b/index.rst
@@ -54,6 +54,7 @@ Table of Contents
    ur_controllers <doc/ur_robot_driver/ur_controllers/doc/index.rst>
    ur_moveit_config <doc/ur_robot_driver/ur_moveit_config/doc/index.rst>
    ur_simulation_gz <doc/ur_simulation_gz/ur_simulation_gz/doc/index.rst>
+   ur_rtde_ros2_publisher <doc/ur_rtde_ros2_publisher/doc/index.rst>
    Tutorial examples <doc/ur_tutorials/tutorial_index.rst>
    doc/migration_notes.rst
    doc/build_status

--- a/jazzy.repos
+++ b/jazzy.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Tutorials.git
     version: main
+  ur_rtde_ros2_publisher:
+    type: git
+    url: https://github.com/UniversalRobots/RTDE_ROS2_Publisher.git
+    version: jazzy

--- a/kilted.repos
+++ b/kilted.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Tutorials.git
     version: main
+  ur_rtde_ros2_publisher:
+    type: git
+    url: https://github.com/UniversalRobots/RTDE_ROS2_Publisher.git
+    version: main

--- a/rolling.repos
+++ b/rolling.repos
@@ -19,4 +19,7 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Tutorials.git
     version: main
-
+  ur_rtde_ros2_publisher:
+    type: git
+    url: https://github.com/UniversalRobots/RTDE_ROS2_Publisher.git
+    version: main

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -13,6 +13,7 @@ SUBREPOS=(
   doc/ur_robot_driver
   doc/ur_simulation_gz
   doc/ur_tutorials
+  doc/ur_rtde_ros2_publisher
 )
 
 DISTROS=(jazzy kilted rolling)


### PR DESCRIPTION
Add the new ur_rtde_ros2_publisher package to the docs.

I did not add it to the build status overview, as this will be covered in another PR where Lyrical builds for all packages will be added.