### PR TITLE
Add Lyrical builds and move rolling build badges to ubuntu resolute

### DIFF
--- a/doc/build_status.rst
+++ b/doc/build_status.rst
@@ -16,6 +16,7 @@ ur_robot_driver
        <th>Humble (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a>)</th>
        <th>Jazzy (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a>)</th>
        <th>Kilted (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/kilted">kilted</a>)</th>
+       <th>Lyrical (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a>)</th>
        <th>Rolling (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a>)</th>
      </tr>
      <tr>
@@ -61,6 +62,20 @@ ur_robot_driver
                 alt="Kilted Semi-Binary Main"/>
          </a> <br />
        </td>
+       <td> <!-- lyrical -->
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml?query=branch%3Amain+">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml/badge.svg?branch=main"
+                alt="Lyrical Binary Main"/>
+         </a> <br />
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml?query=branch%3Amain+">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml/badge.svg?branch=main"
+                alt="Lyrical Binary Testing"/>
+         </a> <br />
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml?query=branch%3Amain+">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml/badge.svg?branch=main"
+                alt="Lyrical Semi-Binary Main"/>
+         </a> <br />
+       </td>
        <td> <!-- rolling -->
          <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-binary-main.yml?query=branch%3Amain+">
            <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-binary-main.yml/badge.svg?branch=main"
@@ -98,12 +113,19 @@ ur_robot_driver
          <a href='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_moveit_config'></a><br/>
          <a href='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_robot_driver'></a>
        </td>
+       <td> <!-- lyrical -->
+         <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+         <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a><br/>
+         <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a><br/>
+         <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a><br/>
+         <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
+       </td>
        <td> <!-- rolling -->
-         <a href='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_calibration'></a><br/>
-         <a href='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_controllers'></a><br/>
-         <a href='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_dashboard_msgs'></a><br/>
-         <a href='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_moveit_config'></a><br/>
-         <a href='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_robot_driver'></a>
+         <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+         <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a><br/>
+         <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a><br/>
+         <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a><br/>
+         <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
        </td>
      </tr>
    </table>
@@ -118,6 +140,7 @@ ur_description
        <th>Humble (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/humble">humble</a>)</th>
        <th>Jazzy (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/jazzy">jazzy</a>)</th>
        <th>Kilted (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/rolling">rolling</a>)</th>
+       <th>Lyrical (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/rolling">rolling</a>)</th>
        <th>Rolling (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/tree/rolling">rolling</a>)</th>
      </tr>
      <tr>
@@ -152,6 +175,16 @@ ur_description
          </a> <br />
        </td>
        <td>
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/actions/workflows/lyrical-binary-main.yml?query=event%3Aschedule++">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/actions/workflows/lyrical-binary-main.yml/badge.svg?event=schedule"
+                alt="Lyrical Binary Main"/>
+         </a> <br />
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/actions/workflows/lyrical-binary-testing.yml?query=event%3Aschedule++">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/actions/workflows/lyrical-binary-testing.yml/badge.svg?event=schedule"
+                alt="Lyrical Binary Testing"/>
+         </a> <br />
+       </td>
+       <td>
          <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/actions/workflows/rolling-binary-main.yml?query=event%3Aschedule++">
            <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/actions/workflows/rolling-binary-main.yml/badge.svg?event=schedule"
                 alt="Rolling Binary Main"/>
@@ -173,7 +206,10 @@ ur_description
          <a href='https://build.ros2.org/job/Kbin_uN64__ur_description__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_description__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_description'></a>
        </td>
        <td>
-         <a href='https://build.ros2.org/job/Rbin_uN64__ur_description__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_description__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_description'></a>
+         <a href='https://build.ros2.org/job/Lbin_uR64__ur_description__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_description__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_description'></a>
+       </td>
+       <td>
+         <a href='https://build.ros2.org/job/Rbin_uR64__ur_description__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_description__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_description'></a>
        </td>
      </tr>
    </table>
@@ -188,6 +224,7 @@ ur_simulation_gz
        <th>Humble (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/humble">humble</a>)</th>
        <th>Jazzy (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a>)</th>
        <th>Kilted (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a>)</th>
+       <th>Lyrical (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a>)</th>
        <th>Rolling (branch <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a>)</th>
      </tr>
      <tr>
@@ -246,6 +283,24 @@ ur_simulation_gz
          </a>
        </td>
        <td>
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/lyrical-binary-main.yml?query=event%3Aschedule++">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/lyrical-binary-main.yml/badge.svg?event=schedule"
+                alt="Lyrical Binary Main"/>
+         </a> <br />
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/lyrical-binary-testing.yml?query=event%3Aschedule++">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/lyrical-binary-testing.yml/badge.svg?event=schedule"
+                alt="Lyrical Binary Testing"/>
+         </a> <br />
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/lyrical-semi-binary-main.yml?query=event%3Aschedule++">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/lyrical-semi-binary-main.yml/badge.svg?event=schedule"
+                alt="Lyrical Semi-Binary Main"/>
+         </a> <br />
+         <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/lyrical-semi-binary-testing.yml?query=event%3Aschedule++">
+           <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/lyrical-semi-binary-testing.yml/badge.svg?event=schedule"
+                alt="Lyrical Semi-Binary Testing"/>
+         </a>
+       </td>
+       <td>
          <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/rolling-binary-main.yml?query=event%3Aschedule++">
            <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/actions/workflows/rolling-binary-main.yml/badge.svg?event=schedule"
                 alt="Rolling Binary Main"/>
@@ -275,7 +330,10 @@ ur_simulation_gz
          <a href='https://build.ros2.org/job/Kbin_uN64__ur_simulation_gz__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_simulation_gz__ubuntu_noble_amd64__binary/badge/icon?subject=uN64__ur_simulation_gz'></a>
        </td>
        <td>
-         <a href='https://build.ros2.org/job/Rbin_uN64__ur_simulation_gz__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_simulation_gz__ubuntu_noble_amd64__binary/badge/icon?subject=uN64__ur_simulation_gz'></a>
+         <a href='https://build.ros2.org/job/Lbin_uR64__ur_simulation_gz__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_simulation_gz__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64__ur_simulation_gz'></a>
+       </td>
+       <td>
+         <a href='https://build.ros2.org/job/Rbin_uR64__ur_simulation_gz__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_simulation_gz__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64__ur_simulation_gz'></a>
        </td>
      </tr>
    </table>


### PR DESCRIPTION
Adds Lyrical builds and migrates rolling builds to ubuntu resolute.

I'll mark this ready for review once all targets are available.